### PR TITLE
Fix typos in dycontrol client

### DIFF
--- a/src/command_dyposition/src/dycontrol_client.cpp
+++ b/src/command_dyposition/src/dycontrol_client.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv)
   rclcpp::init(argc, argv);
 
   if (argc != 2) {
-      RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "usage: dynamixek_control_client X"); //set postion value
+      RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "usage: dynamixel_control_client X"); // set position value
       return 1;
   }
 
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
   if (rclcpp::spin_until_future_complete(node, result) ==
     rclcpp::FutureReturnCode::SUCCESS)
   {
-    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Succesed to set correct position");
+    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Succeeded to set correct position");
 
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to set correct position");


### PR DESCRIPTION
## Summary
- fix typos in dycontrol_client.cpp comment and log message

## Testing
- `colcon build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf5d68d208333ab624195638ff20c